### PR TITLE
Fixes related to table related and image placeholders

### DIFF
--- a/DocumentService/DocumentService.csproj
+++ b/DocumentService/DocumentService.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DocumentService/Word/Models/TableData.cs
+++ b/DocumentService/Word/Models/TableData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace DocumentService.Word
+namespace DocumentService.Word.Models
 {
     public class TableData
     {

--- a/DocumentService/Word/WordDocumentGenerator.cs
+++ b/DocumentService/Word/WordDocumentGenerator.cs
@@ -148,25 +148,21 @@ namespace DocumentService.Word
             {
                 foreach (XWPFTableCell cell in row.GetTableCells())
                 {
-                    if (cell.Paragraphs.Count <= 0)
+                    foreach (XWPFParagraph paragraph in cell.Paragraphs)
                     {
-                        continue;
-                    }
+                        // Get a list of all placeholders in the current cell
+                        List<string> placeholdersTobeReplaced = Regex.Matches(paragraph.ParagraphText, @"{[a-zA-Z]+}")
+                                                                 .Cast<Match>()
+                                                                 .Select(s => s.Groups[0].Value).ToList();
 
-                    XWPFParagraph paragraph = cell.Paragraphs[0];
-
-                    // Get a list of all placeholders in the current cell
-                    List<string> placeholdersTobeReplaced = Regex.Matches(paragraph.ParagraphText, @"{[a-zA-Z]+}")
-                                                             .Cast<Match>()
-                                                             .Select(s => s.Groups[0].Value).ToList();
-
-                    // For each placeholder in the cell
-                    foreach (string placeholder in placeholdersTobeReplaced)
-                    {
-                        // replace the placeholder with its value
-                        if (tableContentPlaceholders.ContainsKey(placeholder))
+                        // For each placeholder in the cell
+                        foreach (string placeholder in placeholdersTobeReplaced)
                         {
-                            paragraph.ReplaceText(placeholder, tableContentPlaceholders[placeholder]);
+                            // replace the placeholder with its value
+                            if (tableContentPlaceholders.ContainsKey(placeholder))
+                            {
+                                paragraph.ReplaceText(placeholder, tableContentPlaceholders[placeholder]);
+                            }
                         }
                     }
                 }

--- a/DocumentService/Word/WordDocumentGenerator.cs
+++ b/DocumentService/Word/WordDocumentGenerator.cs
@@ -243,6 +243,10 @@ namespace DocumentService.Word
                             {
                                 string imagePath = imagePlaceholders[docProperty.Name];
 
+                                /*
+                                 * WebClient has been deprecated and we need to use HTTPClient.
+                                 * This involves the methods to be asynchronous.
+                                 */
                                 using (WebClient webClient = new WebClient())
                                 {
                                     writer.Write(webClient.DownloadData(imagePath));

--- a/DocumentService/Word/WordDocumentGenerator.cs
+++ b/DocumentService/Word/WordDocumentGenerator.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 
 namespace DocumentService.Word
@@ -240,7 +241,21 @@ namespace DocumentService.Word
 
                             using (var writer = new BinaryWriter(imagePart.GetStream()))
                             {
-                                writer.Write(File.ReadAllBytes(imagePlaceholders[docProperty.Name]));
+                                string imagePath = imagePlaceholders[docProperty.Name];
+
+                                if (Uri.IsWellFormedUriString(imagePath, UriKind.Absolute))
+                                {
+                                    // If the image path is a URL then download data as byte array and write
+                                    using (WebClient webClient = new WebClient())
+                                    {
+                                        writer.Write(webClient.DownloadData(imagePath));
+                                    }
+                                }
+                                else
+                                {
+                                    // Else read all bytes from source file and write
+                                    writer.Write(File.ReadAllBytes(imagePath));
+                                }
                             }
                         }
                     }

--- a/DocumentService/Word/WordDocumentGenerator.cs
+++ b/DocumentService/Word/WordDocumentGenerator.cs
@@ -243,18 +243,9 @@ namespace DocumentService.Word
                             {
                                 string imagePath = imagePlaceholders[docProperty.Name];
 
-                                if (Uri.IsWellFormedUriString(imagePath, UriKind.Absolute))
+                                using (WebClient webClient = new WebClient())
                                 {
-                                    // If the image path is a URL then download data as byte array and write
-                                    using (WebClient webClient = new WebClient())
-                                    {
-                                        writer.Write(webClient.DownloadData(imagePath));
-                                    }
-                                }
-                                else
-                                {
-                                    // Else read all bytes from source file and write
-                                    writer.Write(File.ReadAllBytes(imagePath));
+                                    writer.Write(webClient.DownloadData(imagePath));
                                 }
                             }
                         }


### PR DESCRIPTION
# Changes
- Update namespace of TableData to `DocumentService.Word.Models`.
- Update `ReplacePlaceHolderOnTables` method, to loop over each paragraph in a cell.
- Update `ReplaceImagePlaceholders` to read images from URLs