### PR TITLE
REST-253: Add EJS support for PDF generator

### DIFF
--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -6,27 +6,36 @@ using DocumentService.Pdf.Models;
 using System.Diagnostics;
 
 namespace DocumentService.Pdf
-{     
+{
     public class PdfDocumentGenerator
     {
-        public static void GeneratePdfByTemplate(string toolFolderAbsolutePath, string templatePath, List<ContentMetaData> metaDataList, string outputFilePath)
+        public static void GeneratePdf(string toolFolderAbsolutePath, string templatePath, List<ContentMetaData> metaDataList, string outputFilePath, bool isEjsTemplate)
         {
-            try 
-            { 
-                if(!File.Exists(templatePath))
+            try
+            {
+                if (!File.Exists(templatePath))
                 {
-                    throw new Exception("The file path you provided is not Valid"); 
+                    throw new Exception("The file path you provided is not valid.");
                 }
-                
-                string modifiedHtmlFilePath =  ReplaceFileElementsWithMetaData(templatePath, metaDataList, outputFilePath);
+
+                string modifiedHtmlFilePath;
+                if (isEjsTemplate)
+                {
+                    modifiedHtmlFilePath = CompileEjsToHtml(templatePath, outputFilePath);
+                }
+                else
+                {
+                    modifiedHtmlFilePath = ReplaceFileElementsWithMetaData(templatePath, metaDataList, outputFilePath);
+                }
+                modifiedHtmlFilePath = ReplaceFileElementsWithMetaData(templatePath, metaDataList, outputFilePath);
+
                 ConvertHtmlToPdf(toolFolderAbsolutePath, modifiedHtmlFilePath, outputFilePath);
-            } 
-            catch(Exception e)
+            }
+            catch (Exception e)
             {
                 throw e;
             }
         }
-
         private static string ReplaceFileElementsWithMetaData(string templatePath, List<ContentMetaData> metaDataList, string outputFilePath)
         {
             string htmlContent = File.ReadAllText(templatePath);
@@ -35,7 +44,7 @@ namespace DocumentService.Pdf
             {
                 htmlContent = htmlContent.Replace($"{{{metaData.Placeholder}}}", metaData.Content);
             }
-                
+
             string directoryPath = Path.GetDirectoryName(outputFilePath);
             string tempHtmlFilePath = Path.Combine(directoryPath, "Temp");
             string tempHtmlFile = Path.Combine(tempHtmlFilePath, "modifiedHtml.html");
@@ -45,7 +54,7 @@ namespace DocumentService.Pdf
                 Directory.CreateDirectory(tempHtmlFilePath);
             }
 
-            File.WriteAllText(tempHtmlFile, htmlContent);    
+            File.WriteAllText(tempHtmlFile, htmlContent);
             return tempHtmlFile;
         }
 
@@ -56,11 +65,11 @@ namespace DocumentService.Pdf
 
             ProcessStartInfo psi = new ProcessStartInfo
             {
-                FileName = wkHtmlToPdfPath, 
-                Arguments = arguments, 
-                RedirectStandardOutput = true, 
-                RedirectStandardError = true, 
-                UseShellExecute = false, 
+                FileName = wkHtmlToPdfPath,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
                 CreateNoWindow = true
             };
 
@@ -74,6 +83,39 @@ namespace DocumentService.Pdf
             }
 
             File.Delete(modifiedHtmlFilePath);
+        }
+        private static string CompileEjsToHtml(string ejsFilePath, string outputFilePath)
+        {
+            string directoryPath = Path.GetDirectoryName(outputFilePath);
+            string tempHtmlFilePath = Path.Combine(directoryPath, "Temp");
+            if (!Directory.Exists(tempHtmlFilePath))
+            {
+                Directory.CreateDirectory(tempHtmlFilePath);
+            }
+
+            string tempHtmlFile = Path.Combine(tempHtmlFilePath, "modifiedHtml.html");
+            // Path to the ejs-cli tool
+            string ejsCliPath = "ejs-cli";
+            // Execute ejs-cli command to compile EJS and produce HTML
+            string ejsCliArgs = $"npx ejs {ejsFilePath} -o {tempHtmlFile}";
+
+            using (Process ejsCliProcess = new Process())
+            {
+                ejsCliProcess.StartInfo.FileName = ejsCliPath;
+                ejsCliProcess.StartInfo.Arguments = ejsCliArgs;
+                ejsCliProcess.StartInfo.RedirectStandardOutput = false;
+                ejsCliProcess.StartInfo.UseShellExecute = true;
+                ejsCliProcess.StartInfo.CreateNoWindow = true;
+                ejsCliProcess.Start();
+                ejsCliProcess.WaitForExit();
+
+                if (ejsCliProcess.ExitCode != 0)
+                {
+                    Console.WriteLine("EJS compilation failed");
+                    return null;
+                }
+            }
+            return tempHtmlFile;
         }
     }
 }

--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -18,9 +18,15 @@ namespace DocumentService.Pdf
                     throw new Exception("The file path you provided is not valid.");
                 }
 
-                // If input template is an ejs file then convert ejs file to an equivalent html
                 if (isEjsTemplate)
                 {
+                    // Validate if template in file path is an ejs file
+                    if (Path.GetExtension(templatePath).ToLower() != ".ejs")
+                    {
+                        throw new Exception("Input template should be a valid EJS file");
+                    }
+
+                    // Convert ejs file to an equivalent html
                     templatePath = ConvertEjsToHTML(templatePath, outputFilePath);
                 }
 

--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -82,7 +82,7 @@ namespace DocumentService.Pdf
                 string errors = process.StandardError.ReadToEnd();
             }
 
-            File.Delete(modifiedHtmlFilePath);
+            //File.Delete(modifiedHtmlFilePath);
         }
         private static string CompileEjsToHtml(string ejsFilePath, string outputFilePath)
         {
@@ -95,19 +95,36 @@ namespace DocumentService.Pdf
 
             string tempHtmlFile = Path.Combine(tempHtmlFilePath, "modifiedHtml.html");
             // Path to the ejs-cli tool
-            string ejsCliPath = "ejs-cli";
+            string ejsCliPath = @"C:\Users\Sephali\AppData\Roaming\npm\ejs-cli";
+
+            //string ejsCliPath = "C:\\Users\\Sephali\\AppData\\Roaming\\npm\\ejs-cli";
+            Console.WriteLine("ejs-cliPath: " + ejsCliPath);
             // Execute ejs-cli command to compile EJS and produce HTML
-            string ejsCliArgs = $"npx ejs {ejsFilePath} -o {tempHtmlFile}";
+            // string ejsCliArgs = $"npx ejs {ejsFilePath} -o {tempHtmlFile}";
+            //string ejsCliArgs = $"/C {ejsCliPath} {ejsFilePath} -o {tempHtmlFile}";
+            Console.Write(ejsFilePath);
+            string ejsCliArgs = $"{ejsCliPath} .\\testnew.ejs -o .\\output.html";
+            Console.WriteLine("Arguments: " + ejsCliArgs);
+            //string ejsCliArgs = $"\"{ejsFilePath}\" -o \"{tempHtmlFile}\"";
 
             using (Process ejsCliProcess = new Process())
             {
-                ejsCliProcess.StartInfo.FileName = ejsCliPath;
+                ejsCliProcess.StartInfo.FileName = "cmd.exe";
                 ejsCliProcess.StartInfo.Arguments = ejsCliArgs;
-                ejsCliProcess.StartInfo.RedirectStandardOutput = false;
-                ejsCliProcess.StartInfo.UseShellExecute = true;
+                ejsCliProcess.StartInfo.RedirectStandardOutput = true;
+                //ejsCliProcess.StartInfo.UseShellExecute = false;
+                ejsCliProcess.StartInfo.RedirectStandardError = true;
+                ejsCliProcess.StartInfo.UseShellExecute = false;
                 ejsCliProcess.StartInfo.CreateNoWindow = true;
                 ejsCliProcess.Start();
                 ejsCliProcess.WaitForExit();
+                //string errors = ejsCliProcess.StandardError.ReadToEnd();
+                //Console.WriteLine(errors);
+
+                //RedirectStandardOutput = true,
+                //RedirectStandardError = true,
+                //UseShellExecute = false,
+                //CreateNoWindow = true
 
                 if (ejsCliProcess.ExitCode != 0)
                 {
@@ -115,6 +132,21 @@ namespace DocumentService.Pdf
                     return null;
                 }
             }
+
+            //ProcessStartInfo psi = new ProcessStartInfo
+            //{
+            //    FileName = ejsCliPath, 
+            //    Arguments = ejsCliArgs, 
+            //    RedirectStandardOutput = false, 
+            //    UseShellExecute = true, 
+            //    CreateNoWindow = true
+            //};
+            //using (Process ejsCliProcess = new Process())
+            //{
+            //    ejsCliProcess.StartInfo = psi; 
+            //    ejsCliProcess.Start(); 
+            //    ejsCliProcess.WaitForExit();
+            //}
             return tempHtmlFile;
         }
     }

--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -33,6 +33,16 @@ namespace DocumentService.Pdf
                 // Modify html template with content data and generate pdf
                 string modifiedHtmlFilePath = ReplaceFileElementsWithMetaData(templatePath, metaDataList, outputFilePath);
                 ConvertHtmlToPdf(toolFolderAbsolutePath, modifiedHtmlFilePath, outputFilePath);
+
+                if (isEjsTemplate)
+                {
+                    // If input template was an ejs file, then the template path contains path to html converted from ejs
+                    if (Path.GetExtension(templatePath).ToLower() == ".html")
+                    {
+                        // If template path contains path to converted html template then delete it
+                        File.Delete(templatePath);
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -1,4 +1,6 @@
 ﻿using DocumentService.Pdf.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -116,6 +118,12 @@ namespace DocumentService.Pdf
             // Generate file path to converted html template
             string tempHtmlFilePath = Path.Combine(tempDirectoryFilePath, "htmlTemplate.html");
 
+            // If the ejs data json is invalid then throw exception
+            if (!string.IsNullOrWhiteSpace(ejsDataJson) && !IsValidJSON(ejsDataJson))
+            {
+                throw new Exception("Received invalid JSON data for EJS template");
+            }
+
             // Write json data string to json file
             string ejsDataJsonFilePath = Path.Combine(tempDirectoryFilePath, "ejsData.json");
             File.WriteAllText(ejsDataJsonFilePath, ejsDataJson);
@@ -146,6 +154,19 @@ namespace DocumentService.Pdf
             File.Delete(ejsDataJsonFilePath);
 
             return tempHtmlFilePath;
+        }
+
+        private static bool IsValidJSON(string json)
+        {
+            try
+            {
+                JToken.Parse(json);
+                return true;
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/Pdf/PdfDocumentGenerator.cs
+++ b/Pdf/PdfDocumentGenerator.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.IO;
+﻿using DocumentService.Pdf.Models;
+using System;
 using System.Collections.Generic;
-using System.Text;
-using DocumentService.Pdf.Models;
 using System.Diagnostics;
+using System.IO;
 
 namespace DocumentService.Pdf
 {
@@ -75,6 +74,10 @@ namespace DocumentService.Pdf
         private static void ConvertHtmlToPdf(string toolFolderAbsolutePath, string modifiedHtmlFilePath, string outputFilePath)
         {
             string wkHtmlToPdfPath = "cmd.exe";
+
+            /*
+             * FIXME: Issue if tools file path has spaces in between
+             */
             string arguments = $"/C {toolFolderAbsolutePath} \"{modifiedHtmlFilePath}\" \"{outputFilePath}\"";
 
             ProcessStartInfo psi = new ProcessStartInfo
@@ -132,7 +135,6 @@ namespace DocumentService.Pdf
                 string output = process.StandardOutput.ReadToEnd();
                 string errors = process.StandardError.ReadToEnd();
             }
-
 
             return tempHtmlFilePath;
         }


### PR DESCRIPTION
Add EJS support for PDF generator
- Update main method for PDF generator to have EJS file template support
- Add method to generate HTML template from EJS template
- Add support for JSON data as string for variables in EJS template

Prerequisite -
- ejs npm package - `npm i ejs` (NodeJS and NPM is required for adding `ejs` package)