### PR TITLE
build: migrate to docker compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Setting up the app in a Docker-based environment enables developers of non-Windo
 9. Then, in the root directory of the project, execute the following command to build a container for `document-service`:
 
 ```shell
-docker-compose -f docker-compose.yaml up
+docker compose -f docker-compose.yaml up
 ```
 
 10. The project will run on `http://localhost:5000`. Please check [Troubleshooting](#troubleshooting) if the build failed.
@@ -80,7 +80,7 @@ E: Failed to fetch http://sample/link/for.file Unable to connect to sample.downl
 docker system prune -a
 
 # rebuild the container
-docker-compose -f docker-compose.yaml up
+docker compose -f docker-compose.yaml up
 ```
 
 **NOTE:** Please go through the [official documentation on prune command](https://docs.docker.com/config/pruning/) before using it.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ Setting up the app in a Docker-based environment enables developers of non-Windo
 ```
 
 8. Ensure Docker is running.
-9. Then, in the root directory of the project, execute the following command to build a container for `document-service`:
+9. Execute the following commands to dockerize `document-service` using `docker-compose.yaml`:
 
 ```shell
-docker compose -f docker-compose.yaml up
+# build the container
+docker compose build
+
+# run the application
+docker compose up
 ```
 
 10. The project will run on `http://localhost:5000`. Please check [Troubleshooting](#troubleshooting) if the build failed.
@@ -80,7 +84,10 @@ E: Failed to fetch http://sample/link/for.file Unable to connect to sample.downl
 docker system prune -a
 
 # rebuild the container
-docker compose -f docker-compose.yaml up
+docker compose build
+
+# run the application
+docker compose up
 ```
 
 **NOTE:** Please go through the [official documentation on prune command](https://docs.docker.com/config/pruning/) before using it.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   document-service:
     build:


### PR DESCRIPTION
## Task Link

[REST-1433](https://pinestem.com/dashboard.html#/tasks/REST-1433/details/?companyId=453&isPrevNext=1)

## Description

- Migrate to docker compose v2 standards for repository
- Remove deprecated version keyword
- Update documentation with docker compose v2 commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README instructions for running the Docker container, clarifying build and run steps and switching to the modern `docker compose` command syntax.

- **Chores**
  - Removed the version declaration from the Docker Compose configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->