### PR TITLE
fix: disable RedirectStandardOutput for PDF generation

### DIFF
--- a/DocumentService/Pdf/PdfDocumentGenerator.cs
+++ b/DocumentService/Pdf/PdfDocumentGenerator.cs
@@ -91,7 +91,7 @@ namespace DocumentService.Pdf
             {
                 FileName = wkHtmlToPdfPath,
                 Arguments = arguments,
-                RedirectStandardOutput = true,
+                RedirectStandardOutput = false,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true


### PR DESCRIPTION
* Fixed deadlock issue when generating large PDFs with wkhtmltopdf
* Cause: both `stdout` and `stderr` were redirected but not drained before `WaitForExit()`
* Large output filled OS pipe buffer, causing process to hang
* Solution: disabled `RedirectStandardOutput` (not needed for wkhtmltopdf)
* Now only `stderr` is read → prevents buffer blockage
* Improves stability for large PDF generation without extra async handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for HTML-to-PDF conversion process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->